### PR TITLE
Adds a bit of sugar to the 'verify' DSL method.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -98,6 +98,7 @@ You can also specify how many times a specific invocation should have occurred (
     double.equal?(:fruit)
 
     verify(double,2).equal?(:fruit)
+    verify(double,2.times).equal?(:fruit) # N.times syntax needs ruby >= 1.8.7
 
 ### Using Argument Matchers
 

--- a/lib/gimme/verifies.rb
+++ b/lib/gimme/verifies.rb
@@ -4,7 +4,7 @@ module Gimme
     attr_accessor :raises_no_method_error
     def initialize(double,times=1)
       @double = double
-      @times = times
+      @times = times.respond_to?(:count) ? times.count : times
       @raises_no_method_error = true
     end
 

--- a/spec/gimme/shared_examples/shared_verifies_examples.rb
+++ b/spec/gimme/shared_examples/shared_verifies_examples.rb
@@ -7,6 +7,13 @@ module Gimme
       Then { result.should_not raise_error }
     end
 
+    context "using the N.times syntax for invocation count" do
+      Given { 2.times { test_double.ferment } }
+      Given(:verifier) { verifier_class.new(test_double, 2.times) }
+      When(:result) { lambda { 2.times { verifier.ferment } } }
+      Then { result.should_not raise_error }
+    end
+
     context "never invoked" do
       When(:result) { lambda { verifier.ferment } }
       Then { result.should raise_error Errors::VerificationFailedError }


### PR DESCRIPTION
This allows for code like 'verify(double, 2.times).equal?(:fruit)' on Ruby 1.8.7 and greater.
