### PR TITLE
Pass blocks sent to doubles along to the stubbed block via block arg

### DIFF
--- a/lib/gimme/invokes_satisfied_stubbing.rb
+++ b/lib/gimme/invokes_satisfied_stubbing.rb
@@ -4,9 +4,9 @@ module Gimme
       @finder = FindsStubbings.new(stubbed_thing)
     end
 
-    def invoke(method, args)
+    def invoke(method, args, block = nil)
       if blk = @finder.find(method, args)
-        blk.call
+        blk.call(block)
       elsif method.to_s[-1,1] == '?'
         false
       else

--- a/lib/gimme/test_double.rb
+++ b/lib/gimme/test_double.rb
@@ -21,7 +21,7 @@ module Gimme
     def method_missing(method, *args, &block)
       method = ResolvesMethods.new(self.cls, method, args).resolve(false)
       Gimme.invocations.increment(self, method, args)
-      InvokesSatisfiedStubbing.new(self).invoke(method, args)
+      InvokesSatisfiedStubbing.new(self).invoke(method, args, block)
     end
 
     def inspect(*args, &blk)

--- a/spec/gimme/test_double_spec.rb
+++ b/spec/gimme/test_double_spec.rb
@@ -40,7 +40,19 @@ module Gimme
         Then { subject.name.should == "pants" }
       end
 
-    end
+      context "when called with a block" do
+        subject { gimme }
 
+        Given do
+          give(subject).process {|blk| blk.call }
+        end
+
+        Then do
+          obj_in_block = false
+          subject.process { obj_in_block = true }
+          obj_in_block.should be_true
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently, any blocks that are passed to methods on the double get dropped in `TestDouble#method_missing`. I would like to pass along blocks so I can test cases where a collaborator provides a method that takes a block. For example,

``` ruby
class Collab
  def wrapper(&block)
    wrap
    block.call
    unwrap
  end
end

class Sut
  def initialize(wrapper)
    @wrapper = wrapper
  end

  def behavior
    @wrapper.wrap { more_behavior }
  end

  def more_behavior
    change_some_state
  end
end

class SutTest
  def test_behavior
    wrapper = gimme
    give(wrapper).wrap {|blk| blk.call }

    sut = Sut.new(wrapper)
    sut.behavior
    assert_equal new_state, sut.state
  end
end
```

My rspec is a little rusty (I've been using gimme a lot :) so hopefully the included test is acceptable. Let me know your thoughts or if I could tweak anything to get this into a state you'd be comfortable merging. Thanks!
