### PR TITLE
Basic verification of class method w/o using spy_on

### DIFF
--- a/lib/gimme/gives_class_methods.rb
+++ b/lib/gimme/gives_class_methods.rb
@@ -18,6 +18,7 @@ module Gimme
       #TODO this will be redundantly overwritten
       meta_class.instance_eval do
         define_method method do |*actual_args|
+          Gimme.invocations.increment(cls, method, actual_args)
           InvokesSatisfiedStubbing.new(cls).invoke(method, actual_args)
         end
       end

--- a/spec/gimme/verifies_class_methods_spec.rb
+++ b/spec/gimme/verifies_class_methods_spec.rb
@@ -42,5 +42,11 @@ module Gimme
         Given(:verifier) { verify!(test_double) }
       end
     end
+
+    context "without a spy" do
+      Given { give!(test_double).season }
+      When { test_double.season }
+      Then { verify(test_double).season }
+    end
   end
 end


### PR DESCRIPTION
I noticed that basic give/verify functionality of class methods wasn't working they way I expected. The behavior was stubbed out, but verification was failing. For example,

``` ruby
class Dog
end

give!(Dog).woof { puts 'BARK!' }
Dog.woof # outputs BARK!
verify(Dog).woof

```

Would result in an error that woof had never been called. I added an invocation increment to the behavior injected by GivesClassMethods. I also added a spec. I'm not sure if this is actually something you want to support, but it seems useful and no other tests broke. Thanks!
