### PR TITLE
Fix typo in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -194,7 +194,7 @@ In cases like these, a captor can be used to "capture" the real argument value t
 ```ruby
 #arrange
 searches_system = gimme(SearchesSystem)
-sut = QueryExecutor.new(searches_sytem)
+sut = QueryExecutor.new(searches_system)
 query_captor = Gimme::Captor.new
 
 #act


### PR DESCRIPTION
Adds missing `s` letter to code example